### PR TITLE
MultiTrigger support + more buffer control from scripts

### DIFF
--- a/core-test/src/main/kotlin/net/dhleong/judo/TestableJudoCore.kt
+++ b/core-test/src/main/kotlin/net/dhleong/judo/TestableJudoCore.kt
@@ -20,6 +20,7 @@ import net.dhleong.judo.render.IJudoBuffer
 import net.dhleong.judo.render.IJudoTabpage
 import net.dhleong.judo.render.IJudoWindow
 import net.dhleong.judo.render.IdManager
+import net.dhleong.judo.trigger.MultiTriggerManager
 import net.dhleong.judo.trigger.TriggerManager
 import net.dhleong.judo.util.InputHistory
 import net.dhleong.judo.util.JudoMainDispatcher
@@ -56,6 +57,7 @@ class TestableJudoCore(
     override val aliases = AliasManager()
     override val events = TestableEventManager()
     override val mapper = MapManager(this, state, mapRenderer)
+    override val multiTriggers = MultiTriggerManager()
     override val triggers = TriggerManager()
     override val prompts = PromptManager()
 

--- a/core/src/main/kotlin/net/dhleong/judo/JudoCore.kt
+++ b/core/src/main/kotlin/net/dhleong/judo/JudoCore.kt
@@ -902,33 +902,6 @@ class JudoCore(
         processAndStripPrompt(line)
     }
 
-    private fun IJudoBuffer.processMultiTriggers(input: FlavorableCharSequence): Boolean {
-        when (val result = multiTriggers.process(input)) {
-            is MultiTriggerResult.Restore -> {
-                deleteLast()
-                for (l in result.lines) {
-                    appendLine(l)
-                }
-                appendLine(input)
-                printUnprocessed("ERROR: processing multi-trigger ${result.triggerId}")
-                return false // "unhandled"; allow other processing
-            }
-
-            is MultiTriggerResult.Error -> {
-                printUnprocessed("ERROR: processing multi-trigger ${result.triggerId}")
-                return false
-            }
-
-            is MultiTriggerResult.Delete -> {
-                deleteLast()
-                return true // stop processing
-            }
-
-            is MultiTriggerResult.Consume -> return true
-            is MultiTriggerResult.Ignore -> return false
-        }
-    }
-
     private fun activateMode(mode: Mode) = renderer.inTransaction {
         renderer.setCursorType(CursorType.BLOCK)
 

--- a/core/src/main/kotlin/net/dhleong/judo/JudoCore.kt
+++ b/core/src/main/kotlin/net/dhleong/judo/JudoCore.kt
@@ -49,7 +49,6 @@ import net.dhleong.judo.net.isTelnetSubsequence
 import net.dhleong.judo.prompt.AUTO_UNIQUE_GROUP_ID
 import net.dhleong.judo.prompt.PromptManager
 import net.dhleong.judo.register.RegisterManager
-import net.dhleong.judo.render.flavor.Flavor
 import net.dhleong.judo.render.FlavorableCharSequence
 import net.dhleong.judo.render.FlavorableStringBuilder
 import net.dhleong.judo.render.IJudoBuffer
@@ -57,6 +56,7 @@ import net.dhleong.judo.render.IJudoTabpage
 import net.dhleong.judo.render.IJudoWindow
 import net.dhleong.judo.render.IdManager
 import net.dhleong.judo.render.PrimaryJudoWindow
+import net.dhleong.judo.render.flavor.Flavor
 import net.dhleong.judo.render.flavor.flavor
 import net.dhleong.judo.render.parseAnsi
 import net.dhleong.judo.render.toFlavorable
@@ -1018,7 +1018,7 @@ class JudoCore(
     @Synchronized internal fun appendOutput(
         output: FlavorableCharSequence,
         process: Boolean = true
-    ) {
+    ) = renderer.inTransaction {
         val buffer = primaryWindow.currentBuffer
         primaryWindow.append(output)
         if (process) {
@@ -1033,7 +1033,11 @@ class JudoCore(
         if (result.length != originalLength) {
             renderer.inTransaction {
                 // we found a prompt! clean up the output
-                outputBuffer.replaceLastLine(result.toFlavorable())
+                if (result.isEmpty()) {
+                    outputBuffer.deleteLast()
+                } else {
+                    outputBuffer.replaceLastLine(result.toFlavorable())
+                }
             }
         }
 

--- a/core/src/main/kotlin/net/dhleong/judo/modes/BaseCmdMode.kt
+++ b/core/src/main/kotlin/net/dhleong/judo/modes/BaseCmdMode.kt
@@ -516,6 +516,9 @@ abstract class BaseCmdMode(
     protected fun queueTrigger(spec: String) =
         enqueueClear(judo.triggers, spec)
 
+    internal fun queueMultiTrigger(id: String) =
+        enqueueClear(judo.multiTriggers, id)
+
     private fun <T> enqueueClear(source: Clearable<T>, entry: T) =
         currentClearableContext?.let {
             clearQueue.add(QueuedClear(it, source, entry))

--- a/core/src/main/kotlin/net/dhleong/judo/modes/CmdMode.kt
+++ b/core/src/main/kotlin/net/dhleong/judo/modes/CmdMode.kt
@@ -19,6 +19,7 @@ import net.dhleong.judo.script.init.initEvents
 import net.dhleong.judo.script.init.initFiles
 import net.dhleong.judo.script.init.initKeymaps
 import net.dhleong.judo.script.init.initModes
+import net.dhleong.judo.script.init.initMultiTriggers
 import net.dhleong.judo.script.init.initPrompts
 import net.dhleong.judo.script.init.initTriggers
 import net.dhleong.judo.script.init.initUtil
@@ -89,6 +90,7 @@ class CmdMode(
             initFiles()
             initKeymaps()
             initModes()
+            initMultiTriggers()
             initPrompts()
             initTriggers()
             initUtil()

--- a/core/src/main/kotlin/net/dhleong/judo/render/JudoBuffer.kt
+++ b/core/src/main/kotlin/net/dhleong/judo/render/JudoBuffer.kt
@@ -3,11 +3,14 @@ package net.dhleong.judo.render
 import net.dhleong.judo.util.CircularArrayList
 
 open class JudoBuffer(
-    ids: IdManager,
+    override val id: Int,
     scrollbackSize: Int = DEFAULT_SCROLLBACK_SIZE
 ) : IJudoBuffer {
 
-    override val id: Int = ids.newBuffer()
+    constructor(
+        ids: IdManager,
+        scrollbackSize: Int = DEFAULT_SCROLLBACK_SIZE
+    ) : this(ids.newBuffer(), scrollbackSize)
 
     private val contents = CircularArrayList<FlavorableCharSequence>(scrollbackSize)
 

--- a/core/src/main/kotlin/net/dhleong/judo/render/JudoBuffer.kt
+++ b/core/src/main/kotlin/net/dhleong/judo/render/JudoBuffer.kt
@@ -37,6 +37,10 @@ open class JudoBuffer(
     }
 
     @Synchronized
+    override fun deleteLast() =
+        contents.removeLast()
+
+    @Synchronized
     override fun replaceLastLine(result: FlavorableCharSequence) {
         contents[contents.lastIndex] = result
     }
@@ -45,6 +49,18 @@ open class JudoBuffer(
     override fun set(newContents: List<FlavorableCharSequence>) {
         clear()
         newContents.forEach(this::appendLine)
+    }
+
+    @Synchronized
+    override fun set(index: Int, line: FlavorableCharSequence) {
+        val newLine = line.indexOf('\n')
+        require(newLine == -1 || newLine == line.lastIndex) {
+            "Line must not have any newline characters in it"
+        }
+        if (!line.endsWith("\n")) {
+            line += '\n'
+        }
+        contents[index] = line
     }
 
     companion object {

--- a/core/src/main/kotlin/net/dhleong/judo/script/Jsr223ScriptingEngine.kt
+++ b/core/src/main/kotlin/net/dhleong/judo/script/Jsr223ScriptingEngine.kt
@@ -106,6 +106,16 @@ abstract class Jsr223ScriptingEngine(
         }
     }
 
+    override fun toJava(fromScript: Any): Any {
+        if (fromScript is Bindings) {
+            val length = fromScript["length"]
+            if ("call" !in fromScript && length is Int) {
+                return Jsr223List(fromScript, length)
+            }
+        }
+        return super.toJava(fromScript)
+    }
+
     override fun toScript(fromJava: Any): Any = when (fromJava) {
         is JudoScriptingEntity.Function<*> ->
             fromJava.toFunctionalInterface(this)
@@ -146,6 +156,16 @@ abstract class Jsr223ScriptingEngine(
         tabpage: IJudoTabpage,
         window: IJudoWindow
     ): IScriptWindow = Jsr223Window(this, tabpage, window)
+}
+
+class Jsr223List(
+    private val fromScript: Bindings, length: Int
+) : AbstractList<Any?>() {
+
+    override val size: Int = length
+
+    override fun get(index: Int): Any? = fromScript[index.toString()]
+
 }
 
 class Jsr223JudoCore(

--- a/core/src/main/kotlin/net/dhleong/judo/script/Jsr223ScriptingEngine.kt
+++ b/core/src/main/kotlin/net/dhleong/judo/script/Jsr223ScriptingEngine.kt
@@ -8,10 +8,12 @@ import net.dhleong.judo.event.IEventManager
 import net.dhleong.judo.logging.ILogManager
 import net.dhleong.judo.mapping.IJudoMap
 import net.dhleong.judo.mapping.IMapManagerPublic
+import net.dhleong.judo.net.toAnsi
 import net.dhleong.judo.prompt.IPromptManager
 import net.dhleong.judo.render.IJudoBuffer
 import net.dhleong.judo.render.IJudoTabpage
 import net.dhleong.judo.render.IJudoWindow
+import net.dhleong.judo.render.toFlavorable
 import net.dhleong.judo.trigger.ITriggerManager
 import net.dhleong.judo.util.PatternSpec
 import java.io.InputStream
@@ -221,8 +223,23 @@ class Jsr223Buffer(
         buffer.clear()
     }
 
+    override fun deleteLast() {
+        buffer.deleteLast()
+    }
+
+    override fun get(index: Int, flags: String): String {
+        val line = buffer[index]
+        return if ("color" in flags) {
+            line.toAnsi()
+        } else line.toString()
+    }
+
     override fun set(contents: List<String>) {
         buffer.set(contents.toFlavorableList())
+    }
+
+    override fun set(index: Int, contents: String) {
+        buffer[index] = contents.toFlavorable()
     }
 
 }

--- a/core/src/main/kotlin/net/dhleong/judo/script/JythonScriptingEngine.kt
+++ b/core/src/main/kotlin/net/dhleong/judo/script/JythonScriptingEngine.kt
@@ -377,7 +377,11 @@ private inline fun flagCheckerFor(type: Class<out Enum<*>>?): (String) -> Boolea
             it.get(type).toString().toLowerCase()
         }.toSet()
 
-        return { input -> stringTypes.contains(input.toLowerCase()) }
+        // input *only* contains items of stringTypes
+        return { input ->
+            input.splitToSequence(" ")
+                .all { it.toLowerCase() in stringTypes }
+        }
     }
 }
 

--- a/core/src/main/kotlin/net/dhleong/judo/script/init/multiTriggers.kt
+++ b/core/src/main/kotlin/net/dhleong/judo/script/init/multiTriggers.kt
@@ -6,6 +6,7 @@ import net.dhleong.judo.script.doc
 import net.dhleong.judo.script.registerFn
 import net.dhleong.judo.trigger.MultiTriggerOptions
 import net.dhleong.judo.trigger.MultiTriggerType
+import net.dhleong.judo.util.Json
 import net.dhleong.judo.util.PatternProcessingFlags
 
 /**
@@ -18,6 +19,7 @@ fun ScriptInitContext.initMultiTriggers() = with(mode) {
             usage(decorator = true) {
                 arg("id", "String")
                 arg("type", "String")
+                arg("config", Map::class.java, isOptional = true)
                 arg("inputSpecs", "List<String/Pattern>")
                 arg("options", "String", flags = PatternProcessingFlags::class.java)
                 arg("handler", "Fn")
@@ -25,18 +27,48 @@ fun ScriptInitContext.initMultiTriggers() = with(mode) {
 
             body { """
                 Declare a multitrigger. See :help alias for more about inputSpec.
+                
+                `config` is an optional map with keys:
+                    maxLines - the most lines that should be captured by this multitrigger;
+                               if more get captured we will stop processing and print an error
                 `options` is an optional, space-separated string that may contain any of:
                      color - Keep color codes in the values passed to the handler
+                     delete - Delete matching lines instead of keeping them in the buffer
+                     
+                In general, you can omit `config` and use `options` like you're used to for
+                other functions. The flags for `options` can also be used as keys for `config`
+                (with boolean values) if you prefer, however.
             """.trimIndent() }
         }
     ) { args: Array<Any> ->
         val id = args[0] as String
-        val flags = if (args.size == 5) {
-            args[3] as String
-        } else ""
-
         val rawType = args[1] as String
-        val rawSpecs = engine.toJava(args[2]) as List<*>
+        val type = MultiTriggerType.valueOf(rawType.toUpperCase())
+
+        val rawSpecs: List<*>
+        var options: MultiTriggerOptions
+        var i = 2
+        if (args[i] is List<*>) {
+            options = MultiTriggerOptions()
+            rawSpecs = args[i++] as List<*>
+        } else {
+            val optionsMap = args[i++] as Map<*, *>
+            options = Json.adapter<MultiTriggerOptions>()
+                .fromJsonValue(optionsMap)
+                ?: MultiTriggerOptions()
+            rawSpecs = args[i++] as List<*>
+        }
+
+        val flags = if (args[i] !is String) ""
+            else {
+                (args[i] as String).also { flags ->
+                    options = options.copy(
+                        color = "color" in flags || options.color,
+                        delete = "delete" in flags || options.delete
+                    )
+                }
+            }
+
         val patterns = rawSpecs.map { rawSpec ->
             compilePatternSpec(rawSpec as Any, flags)
         }
@@ -47,11 +79,8 @@ fun ScriptInitContext.initMultiTriggers() = with(mode) {
         queueMultiTrigger(id)
         judo.multiTriggers.define(
             id = id,
-            type = MultiTriggerType.valueOf(rawType.toUpperCase()),
-            options = MultiTriggerOptions(
-                color = "color" in flags,
-                delete = "delete" in flags
-            ),
+            type = type,
+            options = options,
             patterns = patterns,
             processor = { fn(it) }
         )

--- a/core/src/main/kotlin/net/dhleong/judo/script/init/multiTriggers.kt
+++ b/core/src/main/kotlin/net/dhleong/judo/script/init/multiTriggers.kt
@@ -1,0 +1,62 @@
+package net.dhleong.judo.script.init
+
+import net.dhleong.judo.script.ScriptInitContext
+import net.dhleong.judo.script.compilePatternSpec
+import net.dhleong.judo.script.doc
+import net.dhleong.judo.script.registerFn
+import net.dhleong.judo.trigger.MultiTriggerOptions
+import net.dhleong.judo.trigger.MultiTriggerType
+import net.dhleong.judo.util.PatternProcessingFlags
+
+/**
+ * @author dhleong
+ */
+fun ScriptInitContext.initMultiTriggers() = with(mode) {
+    registerFn<Unit>(
+        "multitrigger",
+        doc {
+            usage(decorator = true) {
+                arg("id", "String")
+                arg("type", "String")
+                arg("inputSpecs", "List<String/Pattern>")
+                arg("options", "String", flags = PatternProcessingFlags::class.java)
+                arg("handler", "Fn")
+            }
+
+            body { """
+                Declare a multitrigger. See :help alias for more about inputSpec.
+                `options` is an optional, space-separated string that may contain any of:
+                     color - Keep color codes in the values passed to the handler
+            """.trimIndent() }
+        }
+    ) { args: Array<Any> ->
+        val id = args[0] as String
+        val flags = if (args.size == 5) {
+            args[3] as String
+        } else ""
+
+        val rawType = args[1] as String
+        val rawSpecs = engine.toJava(args[2]) as List<*>
+        val patterns = rawSpecs.map { rawSpec ->
+            compilePatternSpec(rawSpec as Any, flags)
+        }
+
+        val rawFn = args.last()
+        val fn = engine.callableToFunction1(rawFn)
+
+        queueMultiTrigger(id)
+        judo.multiTriggers.define(
+            id = id,
+            type = MultiTriggerType.valueOf(rawType.toUpperCase()),
+            options = MultiTriggerOptions(
+                color = "color" in flags,
+                delete = "delete" in flags
+            ),
+            patterns = patterns,
+            processor = {
+                @Suppress("UNCHECKED_CAST")
+                fn(it as Array<Any?>)
+            }
+        )
+    }
+}

--- a/core/src/main/kotlin/net/dhleong/judo/script/init/multiTriggers.kt
+++ b/core/src/main/kotlin/net/dhleong/judo/script/init/multiTriggers.kt
@@ -53,10 +53,7 @@ fun ScriptInitContext.initMultiTriggers() = with(mode) {
                 delete = "delete" in flags
             ),
             patterns = patterns,
-            processor = {
-                @Suppress("UNCHECKED_CAST")
-                fn(it as Array<Any?>)
-            }
+            processor = { fn(it) }
         )
     }
 }

--- a/core/src/main/kotlin/net/dhleong/judo/script/init/multiTriggers.kt
+++ b/core/src/main/kotlin/net/dhleong/judo/script/init/multiTriggers.kt
@@ -28,6 +28,11 @@ fun ScriptInitContext.initMultiTriggers() = with(mode) {
             body { """
                 Declare a multitrigger. See :help alias for more about inputSpec.
                 
+                `type` must be one of:
+                    "range" - expects two values for inputSpecs: a *start* and an *end*.
+                              The multitrigger will start collecting lines when *start*
+                              matches and stop when *end* matches, and all matched lines
+                              will be sent to the handler in a list
                 `config` is an optional map with keys:
                     maxLines - the most lines that should be captured by this multitrigger;
                                if more get captured we will stop processing and print an error

--- a/core/src/main/kotlin/net/dhleong/judo/script/init/windows.kt
+++ b/core/src/main/kotlin/net/dhleong/judo/script/init/windows.kt
@@ -24,7 +24,14 @@ fun ScriptInitContext.initWindows() {
                 id - The buffer's unique, numeric ID
                 append(line: String) - Append a line to the buffer
                 clear() - Remove all lines from the buffer
-                set(lines: String[]) - Replace the buffer's contents
+                deleteLast() - Remove the last (most-recently added) line 
+                               in the buffer
+                get(index: Int[, flags: String]) - Get a line from the buffer
+                               by 0-based index. If `flags` includes "color"
+                               the returned String will include ANSI color codes
+                set(index: Int, line: String) - Replace the contents of a line
+                               in the buffer by 0-based index
+                set(lines: String[]) - Replace the buffer's entire contents
                                        with the given lines list
             Buffer also supports len() to get the number of lines
         """.trimIndent()

--- a/core/src/main/kotlin/net/dhleong/judo/trigger/MultiTriggerManager.kt
+++ b/core/src/main/kotlin/net/dhleong/judo/trigger/MultiTriggerManager.kt
@@ -87,6 +87,14 @@ fun IMultiTriggerManager.processMultiTriggers(
             return true // stop processing
         }
 
+        is MultiTriggerResult.Process -> {
+            if (result.result is MultiTriggerResult.Delete) {
+                buffer.deleteLast()
+            }
+            result.process()
+            return true
+        }
+
         is MultiTriggerResult.Consume -> return true
         is MultiTriggerResult.Ignore -> return false
     }

--- a/core/src/main/kotlin/net/dhleong/judo/trigger/MultiTriggerManager.kt
+++ b/core/src/main/kotlin/net/dhleong/judo/trigger/MultiTriggerManager.kt
@@ -75,12 +75,12 @@ fun IMultiTriggerManager.processMultiTriggers(
                 buffer.appendLine(l)
             }
             buffer.appendLine(input)
-            judo.printRaw("ERROR: processing multi-trigger ${result.triggerId}")
+            judo.printRaw("ERROR: processing multi-trigger ${result.triggerId}: ${result.reason}")
             return false // "unhandled"; allow other processing
         }
 
         is MultiTriggerResult.Error -> {
-            judo.printRaw("ERROR: processing multi-trigger ${result.triggerId}")
+            judo.printRaw("ERROR: processing multi-trigger ${result.triggerId}: ${result.reason}")
             return false
         }
 

--- a/core/src/main/kotlin/net/dhleong/judo/trigger/MultiTriggerManager.kt
+++ b/core/src/main/kotlin/net/dhleong/judo/trigger/MultiTriggerManager.kt
@@ -8,6 +8,7 @@ import net.dhleong.judo.util.PatternSpec
 
 interface MultiTrigger {
     val id: String
+    val options: MultiTriggerOptions
     fun process(line: FlavorableCharSequence): MultiTriggerResult
 }
 
@@ -59,6 +60,7 @@ class MultiTriggerManager : IMultiTriggerManager {
 
     override fun clear(entry: String) = undefine(entry)
 
+    operator fun get(id: String) = triggers.first { it.id == id }
 }
 
 fun IMultiTriggerManager.processMultiTriggers(

--- a/core/src/main/kotlin/net/dhleong/judo/trigger/MultiTriggerManager.kt
+++ b/core/src/main/kotlin/net/dhleong/judo/trigger/MultiTriggerManager.kt
@@ -23,7 +23,7 @@ class MultiTriggerManager : IMultiTriggerManager {
         type: MultiTriggerType,
         options: MultiTriggerOptions,
         patterns: List<PatternSpec>,
-        processor: TriggerProcessor
+        processor: MultiTriggerProcessor
     ) {
         undefine(id)
 

--- a/core/src/main/kotlin/net/dhleong/judo/trigger/MultiTriggerManager.kt
+++ b/core/src/main/kotlin/net/dhleong/judo/trigger/MultiTriggerManager.kt
@@ -1,0 +1,93 @@
+package net.dhleong.judo.trigger
+
+import net.dhleong.judo.IJudoCore
+import net.dhleong.judo.render.FlavorableCharSequence
+import net.dhleong.judo.render.IJudoBuffer
+import net.dhleong.judo.trigger.multi.RangeMultiTrigger
+import net.dhleong.judo.util.PatternSpec
+
+interface MultiTrigger {
+    val id: String
+    fun process(line: FlavorableCharSequence): MultiTriggerResult
+}
+
+/**
+ * @author dhleong
+ */
+class MultiTriggerManager : IMultiTriggerManager {
+
+    private val triggers = mutableListOf<MultiTrigger>()
+
+    override fun define(
+        id: String,
+        type: MultiTriggerType,
+        options: MultiTriggerOptions,
+        patterns: List<PatternSpec>,
+        processor: TriggerProcessor
+    ) {
+        undefine(id)
+
+        triggers += when (type) {
+            MultiTriggerType.RANGE -> RangeMultiTrigger(
+                id,
+                options,
+                patterns[0],
+                patterns[1],
+                processor
+            )
+        }
+    }
+
+    override fun process(input: FlavorableCharSequence): MultiTriggerResult {
+        for (trigger in triggers) {
+            val result = trigger.process(input)
+            if (result !is MultiTriggerResult.Ignore) {
+                return result
+            }
+        }
+
+        return MultiTriggerResult.Ignore
+    }
+
+    override fun undefine(id: String) {
+        triggers.removeIf { it.id == id }
+    }
+
+    override fun clear() {
+        triggers.clear()
+    }
+
+    override fun clear(entry: String) = undefine(entry)
+
+}
+
+fun IMultiTriggerManager.processMultiTriggers(
+    buffer: IJudoBuffer,
+    judo: IJudoCore,
+    input: FlavorableCharSequence
+): Boolean {
+    when (val result = process(input)) {
+        is MultiTriggerResult.Restore -> {
+            buffer.deleteLast()
+            for (l in result.lines) {
+                buffer.appendLine(l)
+            }
+            buffer.appendLine(input)
+            judo.printRaw("ERROR: processing multi-trigger ${result.triggerId}")
+            return false // "unhandled"; allow other processing
+        }
+
+        is MultiTriggerResult.Error -> {
+            judo.printRaw("ERROR: processing multi-trigger ${result.triggerId}")
+            return false
+        }
+
+        is MultiTriggerResult.Delete -> {
+            buffer.deleteLast()
+            return true // stop processing
+        }
+
+        is MultiTriggerResult.Consume -> return true
+        is MultiTriggerResult.Ignore -> return false
+    }
+}

--- a/core/src/main/kotlin/net/dhleong/judo/trigger/multi/RangeMultiTrigger.kt
+++ b/core/src/main/kotlin/net/dhleong/judo/trigger/multi/RangeMultiTrigger.kt
@@ -1,0 +1,85 @@
+package net.dhleong.judo.trigger.multi
+
+import net.dhleong.judo.net.toAnsi
+import net.dhleong.judo.render.FlavorableCharSequence
+import net.dhleong.judo.render.IJudoBuffer
+import net.dhleong.judo.render.JudoBuffer
+import net.dhleong.judo.trigger.MultiTrigger
+import net.dhleong.judo.trigger.MultiTriggerOptions
+import net.dhleong.judo.trigger.MultiTriggerResult
+import net.dhleong.judo.trigger.TriggerProcessor
+import net.dhleong.judo.util.PatternSpec
+
+/**
+ * @author dhleong
+ */
+class RangeMultiTrigger(
+    override val id: String,
+    private val options: MultiTriggerOptions,
+    private val start: PatternSpec,
+    private val stop: PatternSpec,
+    private val processor: TriggerProcessor
+) : MultiTrigger {
+
+    private var reading = false
+    private val buffer = JudoBuffer(id = -1, scrollbackSize = options.maxLines)
+
+    override fun process(line: FlavorableCharSequence): MultiTriggerResult =
+        if (reading) processEnd(line)
+        else processStart(line)
+
+    private fun processStart(line: FlavorableCharSequence): MultiTriggerResult {
+        if (!start.matcher(line).find()) return MultiTriggerResult.Ignore
+
+        reading = true
+        buffer.append(line)
+        if (options.delete) {
+            return MultiTriggerResult.Delete
+        }
+
+        return MultiTriggerResult.Consume
+    }
+
+    private fun processEnd(line: FlavorableCharSequence): MultiTriggerResult {
+        if (stop.matcher(line).find()) {
+            reading = false
+            buffer.append(line)
+
+            val lines = buffer.consumeLines()
+
+            this.processor(lines)
+
+            return if (options.delete) MultiTriggerResult.Delete
+                else MultiTriggerResult.Consume
+        }
+
+        val giveUp = buffer.size >= options.maxLines
+        return when {
+            giveUp && options.delete -> MultiTriggerResult.Restore(
+                id,
+                buffer.copyLines()
+            )
+
+            giveUp -> {
+                buffer.clear()
+                MultiTriggerResult.Consume
+            }
+
+            else -> {
+                buffer.append(line)
+                if (options.delete) MultiTriggerResult.Consume
+                else MultiTriggerResult.Delete
+            }
+        }
+    }
+
+    private fun IJudoBuffer.consumeLines(): Array<String> =
+        Array(size) {
+            if (options.color) this[it].toAnsi()
+            else this[it].toString()
+        }.also { clear() }
+
+    private fun IJudoBuffer.copyLines(): List<FlavorableCharSequence> =
+        List(size) { this[it] }
+            .also { clear() }
+}

--- a/core/src/main/kotlin/net/dhleong/judo/trigger/multi/RangeMultiTrigger.kt
+++ b/core/src/main/kotlin/net/dhleong/judo/trigger/multi/RangeMultiTrigger.kt
@@ -19,7 +19,7 @@ private val MultiTriggerOptions.consumeResult: MultiTriggerResult
  */
 class RangeMultiTrigger(
     override val id: String,
-    private val options: MultiTriggerOptions,
+    override val options: MultiTriggerOptions,
     private val start: PatternSpec,
     private val stop: PatternSpec,
     private val processor: MultiTriggerProcessor

--- a/core/src/main/kotlin/net/dhleong/judo/trigger/multi/RangeMultiTrigger.kt
+++ b/core/src/main/kotlin/net/dhleong/judo/trigger/multi/RangeMultiTrigger.kt
@@ -6,8 +6,8 @@ import net.dhleong.judo.render.IJudoBuffer
 import net.dhleong.judo.render.JudoBuffer
 import net.dhleong.judo.trigger.MultiTrigger
 import net.dhleong.judo.trigger.MultiTriggerOptions
+import net.dhleong.judo.trigger.MultiTriggerProcessor
 import net.dhleong.judo.trigger.MultiTriggerResult
-import net.dhleong.judo.trigger.TriggerProcessor
 import net.dhleong.judo.util.PatternSpec
 
 /**
@@ -18,7 +18,7 @@ class RangeMultiTrigger(
     private val options: MultiTriggerOptions,
     private val start: PatternSpec,
     private val stop: PatternSpec,
-    private val processor: TriggerProcessor
+    private val processor: MultiTriggerProcessor
 ) : MultiTrigger {
 
     private var reading = false
@@ -45,7 +45,7 @@ class RangeMultiTrigger(
             reading = false
             buffer.append(line)
 
-            val lines = buffer.consumeLines()
+            val lines = buffer.consumeStringLines()
 
             this.processor(lines)
 
@@ -57,7 +57,7 @@ class RangeMultiTrigger(
         return when {
             giveUp && options.delete -> MultiTriggerResult.Restore(
                 id,
-                buffer.copyLines()
+                buffer.consumeLines()
             )
 
             giveUp -> {
@@ -73,13 +73,13 @@ class RangeMultiTrigger(
         }
     }
 
-    private fun IJudoBuffer.consumeLines(): Array<String> =
-        Array(size) {
+    private fun IJudoBuffer.consumeStringLines(): List<String> =
+        List(size) {
             if (options.color) this[it].toAnsi()
             else this[it].toString()
         }.also { clear() }
 
-    private fun IJudoBuffer.copyLines(): List<FlavorableCharSequence> =
+    private fun IJudoBuffer.consumeLines(): List<FlavorableCharSequence> =
         List(size) { this[it] }
             .also { clear() }
 }

--- a/core/src/main/kotlin/net/dhleong/judo/trigger/multi/RangeMultiTrigger.kt
+++ b/core/src/main/kotlin/net/dhleong/judo/trigger/multi/RangeMultiTrigger.kt
@@ -10,6 +10,10 @@ import net.dhleong.judo.trigger.MultiTriggerProcessor
 import net.dhleong.judo.trigger.MultiTriggerResult
 import net.dhleong.judo.util.PatternSpec
 
+private val MultiTriggerOptions.consumeResult: MultiTriggerResult
+    get() = if (delete) MultiTriggerResult.Delete
+        else MultiTriggerResult.Consume
+
 /**
  * @author dhleong
  */
@@ -33,11 +37,7 @@ class RangeMultiTrigger(
 
         reading = true
         buffer.append(line)
-        if (options.delete) {
-            return MultiTriggerResult.Delete
-        }
-
-        return MultiTriggerResult.Consume
+        return options.consumeResult
     }
 
     private fun processEnd(line: FlavorableCharSequence): MultiTriggerResult {
@@ -47,10 +47,11 @@ class RangeMultiTrigger(
 
             val lines = buffer.consumeStringLines()
 
-            this.processor(lines)
-
-            return if (options.delete) MultiTriggerResult.Delete
-                else MultiTriggerResult.Consume
+            return MultiTriggerResult.Process(
+                processor,
+                lines,
+                options.consumeResult
+            )
         }
 
         val giveUp = buffer.size >= options.maxLines
@@ -67,8 +68,7 @@ class RangeMultiTrigger(
 
             else -> {
                 buffer.append(line)
-                if (options.delete) MultiTriggerResult.Consume
-                else MultiTriggerResult.Delete
+                options.consumeResult
             }
         }
     }

--- a/core/src/main/kotlin/net/dhleong/judo/trigger/multi/RangeMultiTrigger.kt
+++ b/core/src/main/kotlin/net/dhleong/judo/trigger/multi/RangeMultiTrigger.kt
@@ -58,12 +58,16 @@ class RangeMultiTrigger(
         return when {
             giveUp && options.delete -> MultiTriggerResult.Restore(
                 id,
+                "end not found after ${options.maxLines} lines",
                 buffer.consumeLines()
             )
 
             giveUp -> {
                 buffer.clear()
-                MultiTriggerResult.Consume
+                MultiTriggerResult.Error(
+                    id,
+                    "end not found after ${options.maxLines} lines"
+                )
             }
 
             else -> {

--- a/core/src/test/kotlin/net/dhleong/judo/JudoCoreTest.kt
+++ b/core/src/test/kotlin/net/dhleong/judo/JudoCoreTest.kt
@@ -130,9 +130,7 @@ class JudoCoreTest {
         }
 
         val buffer = judo.renderer.currentTabpage.currentWindow.currentBuffer
-        assertThat(buffer).hasLines(
-            ""
-        )
+        assertThat(buffer).hasSize(0)
     }
 
     @Test fun buildPromptWithAnsi() {

--- a/core/src/test/kotlin/net/dhleong/judo/modes/cmd/CmdModeMultiTriggerTest.kt
+++ b/core/src/test/kotlin/net/dhleong/judo/modes/cmd/CmdModeMultiTriggerTest.kt
@@ -5,6 +5,7 @@ import assertk.assertions.containsExactly
 import assertk.assertions.hasSize
 import assertk.assertions.isEmpty
 import kotlinx.coroutines.runBlocking
+import net.dhleong.judo.hasLines
 import net.dhleong.judo.hasSize
 import net.dhleong.judo.render.FlavorableStringBuilder
 import net.dhleong.judo.script.ScriptingEngine
@@ -21,13 +22,14 @@ class CmdModeMultiTriggerTest(
     factory: ScriptingEngine.Factory
 ) : AbstractCmdModeTest(factory) {
 
-    @Test fun `MultiTrigger`() = runBlocking {
+    @Test fun `RangeMultiTrigger extracts all lines`() = runBlocking {
         mode.execute(when (scriptType()) {
             SupportedScriptTypes.PY -> """
+                import re
                 @multitrigger('id', 'range', [
-                   "Take my love",
-                   "Take me where",
-                ])
+                   re.compile(r'^Take my love'),
+                   re.compile(r'^Take me where'),
+                ], 'delete')
                 def handleTrigger(lines): 
                     for l in lines:
                         print(l)
@@ -37,7 +39,7 @@ class CmdModeMultiTriggerTest(
                 multitrigger('id', 'range', [
                    "Take my love",
                    "Take me where",
-                ], function(lines) {
+                ], 'delete', function(lines) {
                     for (i=0; i < lines.length; ++i) {
                         print(lines[i]);
                     }
@@ -60,6 +62,49 @@ class CmdModeMultiTriggerTest(
 
         @Suppress("UNCHECKED_CAST")
         assertThat(judo.prints).containsExactly(
+            "Take my love\n",
+            "Take my land\n",
+            "Take me where\n"
+        )
+    }
+
+    @Test fun `RangeMultiTrigger arg can be passed to Buffer#set`() = runBlocking {
+        mode.execute(when (scriptType()) {
+            SupportedScriptTypes.PY -> """
+                import re
+                @multitrigger('id', 'range', [
+                   re.compile(r'^Take my love'),
+                   re.compile(r'^Take me where'),
+                ], 'delete')
+                def handleTrigger(lines): 
+                    judo.current.buffer.set(lines)
+            """.trimIndent()
+
+            SupportedScriptTypes.JS -> """
+                multitrigger('id', 'range', [
+                   "Take my love",
+                   "Take me where",
+                ], 'delete', function(lines) {
+                    judo.current.buffer.set(lines)
+                });
+            """.trimIndent()
+        })
+
+        val buffer = judo.renderer.currentTabpage.currentWindow.currentBuffer
+        judo.multiTriggers.apply {
+            process("Take my love")
+            process("Take my land")
+
+            // multi trigger is consuming
+            assertThat(buffer).hasSize(0)
+            assertThat(judo.prints).isEmpty()
+
+            process("Take me where")
+        }
+        assertThat(buffer).hasSize(3)
+
+        @Suppress("UNCHECKED_CAST")
+        assertThat(buffer).hasLines(
             "Take my love\n",
             "Take my land\n",
             "Take me where\n"

--- a/core/src/test/kotlin/net/dhleong/judo/modes/cmd/CmdModeMultiTriggerTest.kt
+++ b/core/src/test/kotlin/net/dhleong/judo/modes/cmd/CmdModeMultiTriggerTest.kt
@@ -1,0 +1,72 @@
+package net.dhleong.judo.modes.cmd
+
+import assertk.assertThat
+import assertk.assertions.containsExactly
+import assertk.assertions.hasSize
+import assertk.assertions.isEmpty
+import kotlinx.coroutines.runBlocking
+import net.dhleong.judo.hasSize
+import net.dhleong.judo.render.FlavorableStringBuilder
+import net.dhleong.judo.script.ScriptingEngine
+import net.dhleong.judo.trigger.MultiTriggerManager
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+/**
+ * @author dhleong
+ */
+@RunWith(Parameterized::class)
+class CmdModeMultiTriggerTest(
+    factory: ScriptingEngine.Factory
+) : AbstractCmdModeTest(factory) {
+
+    @Test fun `MultiTrigger`() = runBlocking {
+        mode.execute(when (scriptType()) {
+            SupportedScriptTypes.PY -> """
+                @multitrigger('id', 'range', [
+                   "Take my love",
+                   "Take me where",
+                ])
+                def handleTrigger(lines): 
+                    for l in lines:
+                        print(l)
+            """.trimIndent()
+
+            SupportedScriptTypes.JS -> """
+                multitrigger('id', 'range', [
+                   "Take my love",
+                   "Take me where",
+                ], function(lines) {
+                    for (i=0; i < lines.length; ++i) {
+                        print(lines[i]);
+                    }
+                });
+            """.trimIndent()
+        })
+
+        val buffer = judo.renderer.currentTabpage.currentWindow.currentBuffer
+        judo.multiTriggers.apply {
+            process("Take my love")
+            process("Take my land")
+
+            // multi trigger is consuming
+            assertThat(buffer).hasSize(0)
+            assertThat(judo.prints).isEmpty()
+
+            process("Take me where")
+        }
+        assertThat(judo.prints).hasSize(3)
+
+        @Suppress("UNCHECKED_CAST")
+        assertThat(judo.prints).containsExactly(
+            "Take my love\n",
+            "Take my land\n",
+            "Take me where\n"
+        )
+    }
+}
+
+fun MultiTriggerManager.process(string: String) = process(FlavorableStringBuilder.withDefaultFlavor(
+    string + "\n"
+))

--- a/docs/Scripting.md
+++ b/docs/Scripting.md
@@ -197,10 +197,13 @@ Name                   | Returned Type | Description
 id                     | `Int`         | The buffer's unique, numeric ID
 `append(line: String)` | `None`        | Append a line of text to the buffer
 `clear()`              | `None`        | Clear all text from the buffer
+`deleteLast()`         | `None`        | Delete the last (most-recently appended) line
+`get(index: Int[, flags: String])`  | `String`      | Get a single line from the buffer. If `color` is included in the optional `flags` String, the ANSI colors are included.
+`set(index: Int, lines: String)`    | `None`        | Replace the contents of a single line
 `set(lines: String[])` | `None`        | Replace the entire contents of the buffer
 
-`Buffer` also supports the `len()` function, which will return how many
-lines of text it contains.
+In Python `Buffer` also supports the `len()` function, which will return how many
+lines of text it contains, and the subscript operator (eg: `buffer[0]`) as an alias for `get()`.
 
 ## Window focus APIs
 

--- a/jline/src/main/kotlin/net/dhleong/judo/jline/JLineBuffer.kt
+++ b/jline/src/main/kotlin/net/dhleong/judo/jline/JLineBuffer.kt
@@ -28,11 +28,19 @@ class JLineBuffer(
         super.clear()
     }
 
+    override fun deleteLast(): FlavorableCharSequence  = renderer.inTransaction {
+        return super.deleteLast()
+    }
+
     override fun replaceLastLine(result: FlavorableCharSequence) = renderer.inTransaction {
         super.replaceLastLine(result)
     }
 
     override fun set(newContents: List<FlavorableCharSequence>) = renderer.inTransaction {
         super.set(newContents)
+    }
+
+    override fun set(index: Int, line: FlavorableCharSequence) = renderer.inTransaction {
+        super.set(index, line)
     }
 }

--- a/jline/src/main/kotlin/net/dhleong/judo/jline/JLinePrimaryWindow.kt
+++ b/jline/src/main/kotlin/net/dhleong/judo/jline/JLinePrimaryWindow.kt
@@ -53,6 +53,10 @@ class JLinePrimaryWindow(
         statusLineOverlaysOutput
     )
 
+    override fun append(text: FlavorableCharSequence) = renderer.inTransaction {
+        super.append(text)
+    }
+
     override fun resize(width: Int, height: Int) = renderer.inTransaction {
         super.resize(width, height)
     }

--- a/model/src/main/kotlin/net/dhleong/judo/IJudoCore.kt
+++ b/model/src/main/kotlin/net/dhleong/judo/IJudoCore.kt
@@ -12,6 +12,7 @@ import net.dhleong.judo.prompt.IPromptManager
 import net.dhleong.judo.register.IRegisterManager
 import net.dhleong.judo.render.IJudoTabpage
 import net.dhleong.judo.script.IJudoScrollable
+import net.dhleong.judo.trigger.IMultiTriggerManager
 import net.dhleong.judo.trigger.ITriggerManager
 import java.io.File
 import java.net.URI
@@ -75,6 +76,7 @@ interface IJudoCore : IJudoScrollable {
     val prompts: IPromptManager
     val registers: IRegisterManager
     val triggers: ITriggerManager
+    val multiTriggers: IMultiTriggerManager
     val state: StateMap
     val renderer: JudoRenderer
     val tabpage: IJudoTabpage

--- a/model/src/main/kotlin/net/dhleong/judo/render/Components.kt
+++ b/model/src/main/kotlin/net/dhleong/judo/render/Components.kt
@@ -22,9 +22,11 @@ interface IJudoBuffer : IJudoAppendable {
     operator fun get(index: Int): FlavorableCharSequence
 
     fun clear()
+    fun deleteLast(): FlavorableCharSequence
     fun replaceLastLine(result: FlavorableCharSequence)
 
     fun set(newContents: List<FlavorableCharSequence>)
+    operator fun set(index: Int, line: FlavorableCharSequence)
 }
 
 interface IJudoWindow : IJudoAppendable, IJudoScrollable {

--- a/model/src/main/kotlin/net/dhleong/judo/script/scriptObjects.kt
+++ b/model/src/main/kotlin/net/dhleong/judo/script/scriptObjects.kt
@@ -45,5 +45,8 @@ interface IScriptBuffer {
 
     fun append(line: String)
     fun clear()
+    fun get(index: Int, flags: String = ""): String
+    fun deleteLast()
     fun set(contents: List<String>)
+    fun set(index: Int, contents: String)
 }

--- a/model/src/main/kotlin/net/dhleong/judo/trigger/IMultiTriggerManager.kt
+++ b/model/src/main/kotlin/net/dhleong/judo/trigger/IMultiTriggerManager.kt
@@ -52,6 +52,8 @@ sealed class MultiTriggerResult {
     ) : MultiTriggerResult()
 }
 
+typealias MultiTriggerProcessor = (args: List<String>) -> Unit
+
 /**
  * @author dhleong
  */
@@ -61,7 +63,7 @@ interface IMultiTriggerManager : Clearable<String> {
         type: MultiTriggerType,
         options: MultiTriggerOptions,
         patterns: List<PatternSpec>,
-        processor: TriggerProcessor
+        processor: MultiTriggerProcessor
     )
 
     fun process(input: FlavorableCharSequence): MultiTriggerResult

--- a/model/src/main/kotlin/net/dhleong/judo/trigger/IMultiTriggerManager.kt
+++ b/model/src/main/kotlin/net/dhleong/judo/trigger/IMultiTriggerManager.kt
@@ -40,6 +40,7 @@ sealed class MultiTriggerResult {
      */
     class Restore(
         val triggerId: String,
+        val reason: String,
         val lines: List<FlavorableCharSequence>
     ) : MultiTriggerResult()
 
@@ -48,7 +49,8 @@ sealed class MultiTriggerResult {
      * with the given [triggerId]
      */
     class Error(
-        val triggerId: String
+        val triggerId: String,
+        val reason: String
     ) : MultiTriggerResult()
 
     /**

--- a/model/src/main/kotlin/net/dhleong/judo/trigger/IMultiTriggerManager.kt
+++ b/model/src/main/kotlin/net/dhleong/judo/trigger/IMultiTriggerManager.kt
@@ -1,0 +1,70 @@
+package net.dhleong.judo.trigger
+
+import net.dhleong.judo.render.FlavorableCharSequence
+import net.dhleong.judo.util.Clearable
+import net.dhleong.judo.util.PatternSpec
+
+enum class MultiTriggerType {
+    /**
+     * Captures a range of text using a single "start"
+     * and a single "end" pattern
+     */
+    RANGE
+}
+
+data class MultiTriggerOptions(
+    val color: Boolean = false,
+    val delete: Boolean = false,
+    val maxLines: Int = 100
+)
+
+sealed class MultiTriggerResult {
+    /** Ignore the processed line, IE: add it to the buffer */
+    object Ignore : MultiTriggerResult()
+
+    /**
+     * Consume the processed line, IE: don't pass it to other
+     * MultiTriggers, but otherwise Ignore it
+     */
+    object Consume : MultiTriggerResult()
+
+    /** Delete the processed line */
+    object Delete : MultiTriggerResult()
+
+    /**
+     * Restore all of the provided [lines] into the buffer and
+     * ignore the processed line (IE: append it *after* the
+     * restored lines).
+     *
+     * This is an error result.
+     */
+    class Restore(
+        val triggerId: String,
+        val lines: List<FlavorableCharSequence>
+    ) : MultiTriggerResult()
+
+    /**
+     * Stop processing due to an error with a multi trigger
+     * with the given [triggerId]
+     */
+    class Error(
+        val triggerId: String
+    ) : MultiTriggerResult()
+}
+
+/**
+ * @author dhleong
+ */
+interface IMultiTriggerManager : Clearable<String> {
+    fun define(
+        id: String,
+        type: MultiTriggerType,
+        options: MultiTriggerOptions,
+        patterns: List<PatternSpec>,
+        processor: TriggerProcessor
+    )
+
+    fun process(input: FlavorableCharSequence): MultiTriggerResult
+
+    fun undefine(id: String)
+}

--- a/model/src/main/kotlin/net/dhleong/judo/trigger/IMultiTriggerManager.kt
+++ b/model/src/main/kotlin/net/dhleong/judo/trigger/IMultiTriggerManager.kt
@@ -50,6 +50,23 @@ sealed class MultiTriggerResult {
     class Error(
         val triggerId: String
     ) : MultiTriggerResult()
+
+    /**
+     * The MultiTrigger has successfully finished consuming
+     * lines, and after handling the [result] the *caller*
+     * should process the collected [lines]. This is done
+     * so that any flag-required delete can happen *before*
+     * the processing takes place, for a consistent result.
+     */
+    class Process(
+        val processor: MultiTriggerProcessor,
+        val lines: List<String>,
+        val result: MultiTriggerResult
+    ) : MultiTriggerResult() {
+        fun process() {
+            processor(lines)
+        }
+    }
 }
 
 typealias MultiTriggerProcessor = (args: List<String>) -> Unit

--- a/model/src/main/kotlin/net/dhleong/judo/util/PatternMatching.kt
+++ b/model/src/main/kotlin/net/dhleong/judo/util/PatternMatching.kt
@@ -18,7 +18,13 @@ enum class PatternProcessingFlags(
      * the processor function; this flag can be used
      * to prevent that.
      */
-    KEEP_COLOR("color");
+    KEEP_COLOR("color"),
+
+    /**
+     * Multi triggers support this option for deleting
+     * the matched lines
+     */
+    DELETE("delete");
 
     override fun toString(): String = stringForm
 


### PR DESCRIPTION
# What is a MultiTrigger?

A `MultiTrigger` is a stateful tool that contains multiple triggers and operates in batch on a collection of lines. As it exists currently, a MultiTrigger is mostly a convenience tool—the only type is `range`, which could be implemented by hand using existing scripting tools. We provide `MultiTrigger`, however, to simplify common use cases, like removing a block of output and sending it to a separate window, for example (see below).

To operate on multiple lines, `MultiTriggers` are typically stateful, meaning each time it sees a line of text it may do something different depending on what it has seen previously. A `range`, for example, does nothing until it sees its "start" line, after which *every* line it sees gets collected, until it finally sees its "end" line, at which point all the lines its collected get sent to your handler. You could implement this with some state and three separate triggers, but `MultiTrigger` makes it more intuitive to do, and also prevents you from accidentally capturing *all output forever* if your "end" pattern isn't quite right.

# Example

In starmourn, you can fairly simply pull out the space map:

```python
space_map = {'window': None,
             'width': 42 }

@multitrigger('space-map', 'range', [
    re.compile(r'^(Location: .+\(.+\))[ ]*$'),
    re.compile(r'^(-----+)[ ]*$'),
], 'color delete')
def extract_space_map(newMapLines):
    newMapLines.pop()

    if space_map['window'] is None:
        primary = judo.current.window
        window = vsplit(space_map['width'])
        space_map['window'] = window
        judo.current.window = primary

    space_map['window'].buffer.set(newMapLines)
```

<img width="1403" alt="Screen Shot 2019-12-30 at 10 06 24 AM" src="https://user-images.githubusercontent.com/816150/71587617-6e560100-2aec-11ea-9d84-eeb2a68ba852.png">
